### PR TITLE
added remove-flags and visible-only options to exporter.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ optional arguments:
 
 ```
 ```
-usage: exporter.py [-h] [--app-root APP_ROOT] [-d DB_URI] [-F SRC_ATTACHMENTS] [-o OUT_FILE] [-O DST_ATTACHMENTS] [--tar] [--gz]
+usage: exporter.py [-h] [--app-root APP_ROOT] [-d DB_URI] [-F SRC_ATTACHMENTS] [-o OUT_FILE] [-O DST_ATTACHMENTS] [--tar] [--gz] [--visible-only] [--remove-flags]
 
 Export a DB full of CTFd challenges and theirs attachments into a portable
 YAML formated specification file and an associated attachment directory
@@ -58,6 +58,8 @@ optional arguments:
   -O DST_ATTACHMENTS   directory for output challenge attachments (default: [OUT_FILENAME].d)
   --tar                if present, output to tar file
   --gz                 if present, compress the tar file (only used if '--tar'is on)
+  --visible-only       if present, ignore hidden challenges
+  --remove-flags       if present, replace flags with a placeholder
 ```
 
 #### YAML Specification:


### PR DESCRIPTION
This PR is to allow the user to remove flags when exporting to publish the challenges yaml file. It is also possible to export only the visible challenges if not all are to be published.