### PR TITLE
Expose export flags in transfer.html

### DIFF
--- a/portable.py
+++ b/portable.py
@@ -23,8 +23,10 @@ def load(app):
             tarfile_backend = TemporaryFile(mode='wb+')
             yamlfile = TemporaryFile(mode='wb+')
             tarball = tarfile.open(fileobj=tarfile_backend, mode='w')
+            visible_only = request.args.get('visibleOnly', default=False, type=bool)
+            remove_flags = request.args.get('removeFlags', default=False, type=bool)
 
-            yamlfile.write(bytes(export_challenges('export.yaml', 'export.d', upload_folder, tarball), "UTF-8"))
+            yamlfile.write(bytes(export_challenges('export.yaml', 'export.d', upload_folder, visible_only, remove_flags, tarfile=tarball), "UTF-8"))
 
             tarinfo = tarfile.TarInfo('export.yaml')
             tarinfo.size = yamlfile.tell()

--- a/transfer.html
+++ b/transfer.html
@@ -21,9 +21,25 @@
         </div>
     </div>
     <hr>
-    <div class="d-block py-3">
-        <a href="{{ request.script_root }}/admin/yaml" class="btn btn-primary" id="export-challenges">Export</a>
+    <div class="row">
+        <div class="col-md-4 form-group">
+            {% with form = Forms.setup.SetupForm() %}
+                <form id="export-form" action="{{ request.script_root }}/admin/yaml" method="GET">
+                    <div class="form-check">
+                        <input type="checkbox" name="removeFlags" id="removeFlags">
+                        <label for="removeFlags">Remove Flags</label>
+                    </div>
+                    <div class="form-check">
+                        <input type="checkbox" name="visibleOnly" id="visibleOnly">
+                        <label for="visibleOnly">Visible Only</label>
+                    </div>
+                    {{ form.nonce() }}
+                    <button class="btn btn-primary" id="export-challenges">Export</button>
+                </form>
+            {% endwith %}
+        </div>
     </div>
+    
 
     <div class="form-group">
         <div id="import-loading" class="alert alert-info" role="alert"><strong>Uploading:</strong> File upload in progress</div>


### PR DESCRIPTION
The PR adds two checkboxs that expose `visible_only` and `remove_flags` in the `export_challenges()`. 

Otherwise, this error occurs:
```
ctfd-dev_1  | ERROR [CTFd] Exception on /admin/yaml [GET]
ctfd-dev_1  | Traceback (most recent call last):
ctfd-dev_1  |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 2447, in wsgi_app
ctfd-dev_1  |     response = self.full_dispatch_request()
ctfd-dev_1  |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1952, in full_dispatch_request
ctfd-dev_1  |     rv = self.handle_user_exception(e)
ctfd-dev_1  |   File "/usr/local/lib/python3.7/site-packages/flask_restx/api.py", line 639, in error_router
ctfd-dev_1  |     return original_handler(e)
ctfd-dev_1  |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1821, in handle_user_exception
ctfd-dev_1  |     reraise(exc_type, exc_value, tb)
ctfd-dev_1  |   File "/usr/local/lib/python3.7/site-packages/flask/_compat.py", line 39, in reraise
ctfd-dev_1  |     raise value
ctfd-dev_1  |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1950, in full_dispatch_request
ctfd-dev_1  |     rv = self.dispatch_request()
ctfd-dev_1  |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1936, in dispatch_request
ctfd-dev_1  |     return self.view_functions[rule.endpoint](**req.view_args)
ctfd-dev_1  |   File "/opt/CTFd/CTFd/utils/decorators/__init__.py", line 133, in admins_only_wrapper
ctfd-dev_1  |     return f(*args, **kwargs)
ctfd-dev_1  |   File "/opt/CTFd/CTFd/plugins/ctfd-portable-challenges-plugin/portable.py", line 30, in transfer_yaml
ctfd-dev_1  |     yamlfile.write(bytes(export_challenges('export.yaml', 'export.d', upload_folder, tarball), "UTF-8"))
ctfd-dev_1  | TypeError: export_challenges() missing 1 required positional argument: 'remove_flags'
```

Frontend:
![](https://i.imgur.com/QpXBtql.png)